### PR TITLE
Simple filtering

### DIFF
--- a/client/Cargo.lock
+++ b/client/Cargo.lock
@@ -1091,9 +1091,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.64"
+version = "0.3.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5f195fe497f702db0f318b07fdd68edb16955aed830df8363d837542f8f935a"
+checksum = "6a88f1bda2bd75b0452a14784937d796722fdebfe50df998aeb3f0b7603019a9"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -2167,19 +2167,20 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.87"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7706a72ab36d8cb1f80ffbf0e071533974a60d0a308d01a5d0375bf60499a342"
+checksum = "128d1e363af62632b8eb57219c8fd7877144af57558fb2ef0368d0087bddeb2e"
 dependencies = [
  "cfg-if",
+ "once_cell",
  "wasm-bindgen-macro",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.87"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ef2b6d3c510e9625e5fe6f509ab07d66a760f0885d858736483c32ed7809abd"
+checksum = "cb6dd4d3ca0ddffd1dd1c9c04f94b868c37ff5fac97c30b97cff2d74fce3a358"
 dependencies = [
  "bumpalo",
  "log",
@@ -2192,9 +2193,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.37"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c02dbc21516f9f1f04f187958890d7e6026df8d16540b7ad9492bc34a67cea03"
+checksum = "cc7ec4f8827a71586374db3e87abdb5a2bb3a15afed140221307c3ec06b1f63b"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -2204,9 +2205,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.87"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dee495e55982a3bd48105a7b947fd2a9b4a8ae3010041b9e0faab3f9cd028f1d"
+checksum = "e79384be7f8f5a9dd5d7167216f022090cf1f9ec128e6e6a482a2cb5c5422c56"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2214,9 +2215,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.87"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
+checksum = "26c6ab57572f7a24a4985830b120de1594465e5d500f24afe89e16b4e833ef68"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2227,9 +2228,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.87"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca6ad05a4870b2bf5fe995117d3728437bd27d7cd5f06f13c17443ef369775a1"
+checksum = "65fc09f10666a9f147042251e0dda9c18f166ff7de300607007e96bdebc1068d"
 
 [[package]]
 name = "wayland-client"

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -12,7 +12,7 @@ eframe = { version = "0.22.0", default-features = false, features = [
     "glow"
 ] }
 log = "0.4"
-wasm-bindgen-futures = "0.4"
+wasm-bindgen-futures = "0.4.45"
 ewebsock = "0.2"
 chrono = "0.4"
 web-time = "1.0.0"

--- a/client/src/app.rs
+++ b/client/src/app.rs
@@ -11,7 +11,7 @@ use rtcp_packets_table::RtcpPacketsTable;
 use rtp_packets_table::RtpPacketsTable;
 use rtp_streams_table::RtpStreamsTable;
 
-use mpegts_info_table::MpegTsInformationsTable;
+use mpegts_info_table::MpegTsInformationTable;
 use mpegts_packets_table::MpegTsPacketsTable;
 use mpegts_stream_plot::MpegTsStreamPlot;
 use mpegts_streams_table::MpegTsStreamsTable;
@@ -58,7 +58,7 @@ pub struct App {
 
     mpegts_packets_table: MpegTsPacketsTable,
     mpegts_streams_table: MpegTsStreamsTable,
-    mpegts_info_table: MpegTsInformationsTable,
+    mpegts_info_table: MpegTsInformationTable,
     mpegts_plot: MpegTsStreamPlot,
 }
 
@@ -83,7 +83,7 @@ impl eframe::App for App {
             Tab::MpegTsSection(section) => match section {
                 MpegTsSection::MpegTsPackets => self.mpegts_packets_table.ui(ctx),
                 MpegTsSection::MpegTsStreams => self.mpegts_streams_table.ui(ctx),
-                MpegTsSection::MpegTsInformations => self.mpegts_info_table.ui(ctx),
+                MpegTsSection::MpegTsInformation => self.mpegts_info_table.ui(ctx),
                 MpegTsSection::MpegTsPlot => self.mpegts_plot.ui(ctx),
             },
         };
@@ -110,7 +110,7 @@ impl App {
 
         let mpegts_packets_table = MpegTsPacketsTable::new(streams.clone());
         let mpegts_streams_table = MpegTsStreamsTable::new(streams.clone());
-        let mpegts_info_table = MpegTsInformationsTable::new(streams.clone(), ws_sender.clone());
+        let mpegts_info_table = MpegTsInformationTable::new(streams.clone(), ws_sender.clone());
         let mpegts_plot = MpegTsStreamPlot::new(streams.clone());
 
         let (tab, selected_source) = get_initial_state(cc);
@@ -206,7 +206,7 @@ impl App {
             Tab::MpegTsSection(section) => match section {
                 MpegTsSection::MpegTsPackets => "📺 MPEG-TS Packets",
                 MpegTsSection::MpegTsStreams => "🎥 MPEG-TS Streams",
-                MpegTsSection::MpegTsInformations => "ℹ️ MPEG-TS Info",
+                MpegTsSection::MpegTsInformation => "ℹ️ MPEG-TS Info",
                 MpegTsSection::MpegTsPlot => "📊 MPEG-TS Plot",
             },
         };

--- a/client/src/app.rs
+++ b/client/src/app.rs
@@ -4,7 +4,7 @@ use eframe::egui;
 use egui::{ComboBox, Ui};
 use ewebsock::{WsEvent, WsMessage, WsReceiver, WsSender};
 use log::{error, warn};
-use netpix_common::{Request, Response, Source, RtpStreamKey, MpegtsStreamKey};
+use netpix_common::{MpegtsStreamKey, Request, Response, RtpStreamKey, Source};
 
 use packets_table::PacketsTable;
 use rtcp_packets_table::RtcpPacketsTable;
@@ -33,6 +33,7 @@ mod mpegts_packets_table;
 mod mpegts_stream_plot;
 mod mpegts_streams_table;
 
+mod filters;
 mod tab;
 
 const SOURCE_KEY: &str = "source";

--- a/client/src/app.rs
+++ b/client/src/app.rs
@@ -33,7 +33,6 @@ mod mpegts_packets_table;
 mod mpegts_stream_plot;
 mod mpegts_streams_table;
 
-mod filters;
 mod tab;
 
 const SOURCE_KEY: &str = "source";

--- a/client/src/app/filters.rs
+++ b/client/src/app/filters.rs
@@ -1,0 +1,183 @@
+use crate::streams::mpegts_stream::MpegTsPacketInfo;
+use netpix_common::mpegts::header::{AdaptationFieldControl, PIDTable};
+use std::str::FromStr;
+
+pub trait PacketFilter {
+    fn matches(&self, info: &FilterContext) -> bool;
+}
+
+pub struct FilterContext<'a> {
+    pub packet: &'a MpegTsPacketInfo,
+    pub pmt_pids: &'a [PIDTable],
+    pub es_pids: &'a [PIDTable],
+    pub pcr_pids: &'a [PIDTable],
+    pub stream_alias: Option<String>,
+}
+
+pub enum FilterType {
+    Description(String),
+    Source(String),
+    Destination(String),
+    Alias(String),
+    Payload(PayloadFilter),
+    PacketPID(usize, String),
+    PID(u16),
+    Type(PacketType),
+}
+
+pub enum PacketType {
+    PAT,
+    PMT,
+    PCRES,
+    ES,
+    PCR,
+}
+
+pub enum PayloadFilter {
+    GreaterThan(usize),
+    LessThan(usize),
+    Equals(String),
+}
+
+impl FromStr for PacketType {
+    type Err = ();
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_uppercase().as_str() {
+            "PAT" => Ok(PacketType::PAT),
+            "PMT" => Ok(PacketType::PMT),
+            "PCR+ES" => Ok(PacketType::PCRES),
+            "ES" => Ok(PacketType::ES),
+            "PCR" => Ok(PacketType::PCR),
+            _ => Err(()),
+        }
+    }
+}
+
+impl PacketFilter for FilterType {
+    fn matches(&self, ctx: &FilterContext) -> bool {
+        match self {
+            FilterType::Description(value) => ctx.packet.id.to_string().contains(value),
+            FilterType::Source(value) => ctx
+                .packet
+                .packet_association_table
+                .source_addr
+                .to_string()
+                .to_lowercase()
+                .contains(value),
+            FilterType::Destination(value) => ctx
+                .packet
+                .packet_association_table
+                .destination_addr
+                .to_string()
+                .to_lowercase()
+                .contains(value),
+            FilterType::Alias(value) => ctx
+                .stream_alias
+                .as_ref()
+                .map(|alias| alias.to_lowercase().contains(value))
+                .unwrap_or(false),
+            FilterType::Payload(payload_filter) => {
+                let payload_size = calculate_payload_size(ctx.packet);
+                match payload_filter {
+                    PayloadFilter::GreaterThan(size) => payload_size > *size,
+                    PayloadFilter::LessThan(size) => payload_size < *size,
+                    PayloadFilter::Equals(value) => payload_size.to_string().contains(value),
+                }
+            }
+            FilterType::PacketPID(index, value) => ctx
+                .packet
+                .content
+                .fragments
+                .get(*index)
+                .map(|fragment| match &fragment.header.pid {
+                    PIDTable::PID(pid) => pid.to_string().contains(value),
+                    _ => fragment
+                        .header
+                        .pid
+                        .to_string()
+                        .to_lowercase()
+                        .contains(value),
+                })
+                .unwrap_or(false),
+            FilterType::PID(pid_value) => ctx.packet.content.fragments.iter().any(
+                |fragment| matches!(fragment.header.pid, PIDTable::PID(pid) if pid == *pid_value),
+            ),
+            FilterType::Type(packet_type) => match_packet_type(ctx, packet_type),
+        }
+    }
+}
+
+pub fn parse_filter(filter: &str) -> Option<FilterType> {
+    if let Some((prefix, value)) = filter.split_once(':') {
+        let value = value.trim().to_lowercase();
+        match prefix.trim() {
+            "desc" => Some(FilterType::Description(value)),
+            "source" => Some(FilterType::Source(value)),
+            "dest" => Some(FilterType::Destination(value)),
+            "alias" => Some(FilterType::Alias(value)),
+            "payload" => parse_payload_filter(&value),
+            p if p.starts_with('p') && p.len() == 2 => {
+                let packet_index = p[1..].parse::<usize>().ok()?.saturating_sub(1);
+                Some(FilterType::PacketPID(packet_index, value))
+            }
+            "pid" => value.parse().ok().map(FilterType::PID),
+            "type" => PacketType::from_str(&value).ok().map(FilterType::Type),
+            _ => None,
+        }
+    } else {
+        None
+    }
+}
+
+fn parse_payload_filter(value: &str) -> Option<FilterType> {
+    if value.starts_with('>') {
+        value[1..]
+            .trim()
+            .parse()
+            .ok()
+            .map(PayloadFilter::GreaterThan)
+    } else if value.starts_with('<') {
+        value[1..].trim().parse().ok().map(PayloadFilter::LessThan)
+    } else {
+        Some(PayloadFilter::Equals(value.to_string()))
+    }
+    .map(FilterType::Payload)
+}
+
+fn calculate_payload_size(packet: &MpegTsPacketInfo) -> usize {
+    packet
+        .content
+        .fragments
+        .iter()
+        .filter(|f| {
+            f.header.adaptation_field_control != AdaptationFieldControl::AdaptationFieldOnly
+        })
+        .filter_map(|f| f.payload.as_ref())
+        .map(|p| p.data.len())
+        .sum()
+}
+
+fn match_packet_type(ctx: &FilterContext, packet_type: &PacketType) -> bool {
+    ctx.packet
+        .content
+        .fragments
+        .iter()
+        .any(|fragment| match (packet_type, &fragment.header.pid) {
+            (PacketType::PAT, PIDTable::ProgramAssociation) => true,
+            (_, PIDTable::PID(pid)) => {
+                let is_pmt = ctx.pmt_pids.contains(&PIDTable::PID(*pid));
+                let is_es = ctx.es_pids.contains(&PIDTable::PID(*pid));
+                let is_pcr = ctx.pcr_pids.contains(&PIDTable::PID(*pid));
+
+                match (packet_type, is_pmt, is_es, is_pcr) {
+                    (PacketType::PMT, true, _, _) => true,
+                    (PacketType::PCRES, _, true, true) => true,
+                    (PacketType::ES, _, true, false) => true,
+                    (PacketType::PCR, _, false, true) => true,
+                    _ => false,
+                }
+            }
+            _ => false,
+        })
+}

--- a/client/src/app/mpegts_info_table.rs
+++ b/client/src/app/mpegts_info_table.rs
@@ -5,13 +5,13 @@ use egui_extras::{Column, TableBody, TableBuilder};
 use ewebsock::WsSender;
 use netpix_common::MpegtsStreamKey;
 
-pub struct MpegTsInformationsTable {
+pub struct MpegTsInformationTable {
     streams: RefStreams,
     ws_sender: WsSender,
     streams_visibility: HashMap<MpegtsStreamKey, bool>,
 }
 
-impl MpegTsInformationsTable {
+impl MpegTsInformationTable {
     pub fn new(streams: RefStreams, ws_sender: WsSender) -> Self {
         Self {
             streams,

--- a/client/src/app/mpegts_packets_table.rs
+++ b/client/src/app/mpegts_packets_table.rs
@@ -60,7 +60,7 @@ impl MpegTsPacketsTable {
             .font(egui::style::TextStyle::Monospace)
             .desired_width(f32::INFINITY)
             .hint_text(
-                "Filter examples: DESC:123, SOURCE:192.168, P1:100, PAYLOAD:>1000, ALIAS:stream1, TYPE:PAT, PID:4096",
+                "Examples: DESC:123 AND TYPE:PAT, SOURCE:192.168 OR DEST:10.0, NOT PID:4096, (TYPE:PMT AND PAYLOAD:>1000)",
             );
 
         ui.horizontal(|ui| {
@@ -102,35 +102,7 @@ impl MpegTsPacketsTable {
         if let Some(filter_type) = parse_filter(&filter) {
             filter_type.matches(&ctx)
         } else {
-            info.packet.id.to_string().contains(&filter)
-                || ctx
-                    .packet
-                    .packet_association_table
-                    .source_addr
-                    .to_string()
-                    .to_lowercase()
-                    .contains(&filter)
-                || ctx
-                    .packet
-                    .packet_association_table
-                    .destination_addr
-                    .to_string()
-                    .to_lowercase()
-                    .contains(&filter)
-                || ctx
-                    .packet
-                    .content
-                    .fragments
-                    .iter()
-                    .any(|fragment| match fragment.header.pid {
-                        PIDTable::PID(pid) => pid.to_string().contains(&filter),
-                        _ => fragment
-                            .header
-                            .pid
-                            .to_string()
-                            .to_lowercase()
-                            .contains(&filter),
-                    })
+            true
         }
     }
 

--- a/client/src/app/mpegts_packets_table.rs
+++ b/client/src/app/mpegts_packets_table.rs
@@ -1,47 +1,37 @@
-use crate::app::filters::{parse_filter, FilterContext, PacketFilter};
-use crate::app::is_mpegts_stream_visible;
-use crate::streams::mpegts_stream::MpegTsPacketInfo;
+mod display;
+mod filters;
+mod types;
+
 use crate::streams::RefStreams;
-use egui::{Color32, RichText, TextEdit};
+use display::{
+    format_packet_text, ES_FORMAT, PAT_FORMAT, PCR_ES_FORMAT, PCR_FORMAT, PID_FORMAT, PMT_FORMAT,
+};
 use egui_extras::{Column, TableBody, TableBuilder};
+use types::{PacketInfo, TableConfig};
+
+use crate::app::is_mpegts_stream_visible;
+use crate::app::mpegts_packets_table::filters::{parse_filter, FilterContext, PacketFilter};
+use crate::streams::mpegts_stream::MpegTsPacketInfo;
+use egui::{Color32, RichText, TextEdit};
 use netpix_common::mpegts::header::{AdaptationFieldControl, PIDTable};
 use netpix_common::mpegts::MpegtsFragment;
-use netpix_common::{MpegtsStreamKey, RtpStreamKey};
+use netpix_common::MpegtsStreamKey;
 use std::collections::HashMap;
 use web_time::Duration;
-
-const ROW_HEIGHT: f32 = 25.0;
-const HEADER_HEIGHT: f32 = 30.0;
-const SPACE_AFTER_FILTER: f32 = 5.0;
-
-const PAT_FORMAT: &str = "PAT";
-const PMT_FORMAT: &str = "PMT";
-const PCR_ES_FORMAT: &str = "PCR+ES";
-const ES_FORMAT: &str = "ES";
-const PCR_FORMAT: &str = "PCR";
-const PID_FORMAT: &str = "PID";
 
 #[derive(Clone)]
 pub struct MpegTsPacketsTable {
     streams: RefStreams,
-    streams_visibility: HashMap<MpegtsStreamKey, bool>,
     filter_buffer: String,
-}
-
-#[derive(Clone)]
-struct PacketInfo<'a> {
-    packet: &'a MpegTsPacketInfo,
-    timestamp: Duration,
-    key: MpegtsStreamKey,
+    config: TableConfig,
 }
 
 impl MpegTsPacketsTable {
     pub fn new(streams: RefStreams) -> Self {
-        let capacity = streams.borrow().mpeg_ts_streams.len();
         Self {
             streams,
-            streams_visibility: HashMap::with_capacity(capacity),
             filter_buffer: String::new(),
+            config: TableConfig::default(),
         }
     }
 
@@ -60,14 +50,10 @@ impl MpegTsPacketsTable {
             .font(egui::style::TextStyle::Monospace)
             .desired_width(f32::INFINITY)
             .hint_text(
-                "Examples: DESC:123 AND TYPE:PAT, SOURCE:192.168 OR DEST:10.0, NOT PID:4096, (TYPE:PMT AND PAYLOAD:>1000)",
+                "Examples: ALIAS:A, DESC:123 AND TYPE:PAT, SOURCE:192.168 OR DEST:10.0, NOT PID:4096, (TYPE:PMT AND PAYLOAD:>1000)",
             );
 
         ui.horizontal(|ui| {
-            if ui.button("↻").on_hover_text("Reset the filter").clicked() {
-                // self.filter_buffer.clear();
-            }
-            ui.button("⏵").on_hover_text("Apply the filter");
             ui.add(text_edit);
         });
     }
@@ -115,36 +101,11 @@ impl MpegTsPacketsTable {
         }
         aliases.sort_by(|(_, a), (_, b)| a.cmp(b));
 
-        ui.horizontal_wrapped(|ui| {
-            ui.label("Filter by: ");
-            for (key, alias) in &aliases {
-                let mut selected = is_mpegts_stream_visible(&mut self.streams_visibility, *key);
-                ui.checkbox(&mut selected, alias);
-            }
-        });
-        ui.add_space(SPACE_AFTER_FILTER);
+        ui.add_space(self.config.space_after_filter);
     }
 
     fn build_table(&mut self, ui: &mut egui::Ui) {
-        let header_labels = [
-            ("No.", "Packet number (including skipped packets)"),
-            ("Alias", "Stream alias"),
-            ("Time", "Packet arrival timestamp"),
-            ("Source", "Source IP address and port"),
-            ("Destination", "Destination IP address and port"),
-            ("P1", "Packet No. 1"),
-            ("P2", "Packet No. 2"),
-            ("P3", "Packet No. 3"),
-            ("P4", "Packet No. 4"),
-            ("P5", "Packet No. 5"),
-            ("P6", "Packet No. 6"),
-            ("P7", "Packet No. 7"),
-            (
-                "Payload Length",
-                "Mpegts payload length without header and adaptation data",
-            ),
-        ];
-        TableBuilder::new(ui)
+        let table = TableBuilder::new(ui)
             .striped(true)
             .resizable(true)
             .stick_to_bottom(true)
@@ -153,13 +114,52 @@ impl MpegTsPacketsTable {
             .column(Column::initial(80.0).at_least(80.0))
             .columns(Column::initial(140.0).at_least(140.0).at_most(155.0), 2)
             .columns(Column::initial(160.0).at_least(160.0), 7)
-            .column(Column::remainder().at_least(80.0))
-            .header(HEADER_HEIGHT, |mut header| {
-                header_labels.iter().for_each(|(label, desc)| {
-                    header.col(|ui| {
-                        ui.heading(label.to_string())
-                            .on_hover_text(desc.to_string());
-                    });
+            .column(Column::remainder().at_least(80.0));
+
+        self.build_table_with_config(table);
+    }
+
+    fn build_table_with_config(&mut self, table: TableBuilder) {
+        table
+            .header(self.config.header_height, |mut header| {
+                header.col(|ui| {
+                    ui.strong("ID");
+                });
+                header.col(|ui| {
+                    ui.strong("Alias");
+                });
+                header.col(|ui| {
+                    ui.strong("Time");
+                });
+                header.col(|ui| {
+                    ui.strong("Source");
+                });
+                header.col(|ui| {
+                    ui.strong("Destination");
+                });
+                header.col(|ui| {
+                    ui.strong("PID 1");
+                });
+                header.col(|ui| {
+                    ui.strong("PID 2");
+                });
+                header.col(|ui| {
+                    ui.strong("PID 3");
+                });
+                header.col(|ui| {
+                    ui.strong("PID 4");
+                });
+                header.col(|ui| {
+                    ui.strong("PID 5");
+                });
+                header.col(|ui| {
+                    ui.strong("PID 6");
+                });
+                header.col(|ui| {
+                    ui.strong("PID 7");
+                });
+                header.col(|ui| {
+                    ui.strong("Payload Size");
                 });
             })
             .body(|body| {
@@ -173,23 +173,7 @@ impl MpegTsPacketsTable {
         let mpegts_packets: Vec<_> = streams
             .mpeg_ts_streams
             .iter()
-            .flat_map(|(_, stream)| {
-                stream.stream_info.packets.iter().map(move |packet| {
-                    let key = (
-                        packet.packet_association_table.source_addr,
-                        packet.packet_association_table.destination_addr,
-                        packet.packet_association_table.protocol,
-                    );
-                    (packet, key)
-                })
-            })
-            .filter_map(|(packet, key)| {
-                if *is_mpegts_stream_visible(&mut self.streams_visibility, key) {
-                    Some(packet)
-                } else {
-                    None
-                }
-            })
+            .flat_map(|(_, stream)| stream.stream_info.packets.iter())
             .collect();
 
         if mpegts_packets.is_empty() {
@@ -250,169 +234,137 @@ impl MpegTsPacketsTable {
             .filter(|info| self.packet_matches_filter(info, &pmt_pids, &es_pids, &pcr_pids))
             .collect();
 
-        body.rows(ROW_HEIGHT, filtered_packets.len(), |row_ix, mut row| {
-            let info = &filtered_packets[row_ix];
+        body.rows(
+            self.config.row_height,
+            filtered_packets.len(),
+            |row_ix, mut row| {
+                let info = &filtered_packets[row_ix];
 
-            row.col(|ui| {
-                ui.label(info.packet.id.to_string());
-            });
+                row.col(|ui| {
+                    ui.label(info.packet.id.to_string());
+                });
 
-            row.col(|ui| {
-                let binding = String::new();
-                let alias = alias_to_display.get(&info.key).unwrap_or(&binding);
-                ui.label(alias);
-            });
+                row.col(|ui| {
+                    let binding = String::new();
+                    let alias = alias_to_display.get(&info.key).unwrap_or(&binding);
+                    ui.label(alias);
+                });
 
-            row.col(|ui| {
-                let timestamp = info.packet.time.saturating_sub(first_ts);
-                ui.label(format!("{:.4}", timestamp.as_secs_f64()));
-            });
-            row.col(|ui| {
-                ui.label(info.packet.packet_association_table.source_addr.to_string());
-            });
-            row.col(|ui| {
-                ui.label(
-                    info.packet
-                        .packet_association_table
-                        .destination_addr
-                        .to_string(),
-                );
-            });
+                row.col(|ui| {
+                    let timestamp = info.packet.time.saturating_sub(first_ts);
+                    ui.label(format!("{:.4}", timestamp.as_secs_f64()));
+                });
+                row.col(|ui| {
+                    ui.label(info.packet.packet_association_table.source_addr.to_string());
+                });
+                row.col(|ui| {
+                    ui.label(
+                        info.packet
+                            .packet_association_table
+                            .destination_addr
+                            .to_string(),
+                    );
+                });
 
-            let mut labels = info
-                .packet
-                .content
-                .fragments
-                .iter()
-                .map(|fragment| match fragment.header.pid {
-                    PIDTable::ProgramAssociation => String::from(PAT_FORMAT),
-                    PIDTable::ConditionalAccess => String::from("CA"),
-                    PIDTable::TransportStreamDescription => String::from("TSD"),
-                    PIDTable::AdaptiveStreamingInformation => String::from("ASI"),
-                    PIDTable::NullPacket => String::from("NullPacket"),
-                    PIDTable::PID(pid) => {
-                        let is_pmt = pmt_pids.contains(&PIDTable::PID(pid));
-                        let is_es = es_pids.contains(&PIDTable::PID(pid));
-                        let is_pcr = pcr_pids.contains(&PIDTable::PID(pid));
+                let mut labels = info
+                    .packet
+                    .content
+                    .fragments
+                    .iter()
+                    .map(|fragment| match fragment.header.pid {
+                        PIDTable::ProgramAssociation => String::from(PAT_FORMAT),
+                        PIDTable::ConditionalAccess => String::from("CA"),
+                        PIDTable::TransportStreamDescription => String::from("TSD"),
+                        PIDTable::AdaptiveStreamingInformation => String::from("ASI"),
+                        PIDTable::NullPacket => String::from("NullPacket"),
+                        PIDTable::PID(pid) => {
+                            let is_pmt = pmt_pids.contains(&PIDTable::PID(pid));
+                            let is_es = es_pids.contains(&PIDTable::PID(pid));
+                            let is_pcr = pcr_pids.contains(&PIDTable::PID(pid));
 
-                        match (is_pmt, is_es, is_pcr) {
-                            (true, _, _) => format!("{} ({})", PMT_FORMAT, pid),
-                            (_, true, true) => format!("{} ({})", PCR_ES_FORMAT, pid),
-                            (_, true, false) => format!("{} ({})", ES_FORMAT, pid),
-                            (_, false, true) => format!("{} ({})", PCR_FORMAT, pid),
-                            _ => format!("{} ({})", PID_FORMAT, pid),
+                            match (is_pmt, is_es, is_pcr) {
+                                (true, _, _) => format!("{} ({})", PMT_FORMAT, pid),
+                                (_, true, true) => format!("{} ({})", PCR_ES_FORMAT, pid),
+                                (_, true, false) => format!("{} ({})", ES_FORMAT, pid),
+                                (_, false, true) => format!("{} ({})", PCR_FORMAT, pid),
+                                _ => format!("{} ({})", PID_FORMAT, pid),
+                            }
                         }
-                    }
-                    PIDTable::IPMPControlInformation => String::from("IPMPControlInformation"),
-                })
-                .into_iter();
+                        PIDTable::IPMPControlInformation => String::from("IPMPControlInformation"),
+                    })
+                    .into_iter();
 
-            let fragments: Vec<_> = info.packet.content.fragments.iter().collect();
+                let fragments: Vec<_> = info.packet.content.fragments.iter().collect();
 
-            let payload_size: usize = fragments
-                .iter()
-                .map(|fragment| {
-                    if fragment.header.adaptation_field_control
-                        == AdaptationFieldControl::AdaptationFieldOnly
-                    {
-                        return 0;
-                    }
-                    fragment
-                        .payload
-                        .as_ref()
-                        .map_or_else(|| 0, |payload| payload.data.len())
-                })
-                .sum();
-            let mut fragments_iter = fragments.iter();
+                let payload_size: usize = fragments
+                    .iter()
+                    .map(|fragment| {
+                        if fragment.header.adaptation_field_control
+                            == AdaptationFieldControl::AdaptationFieldOnly
+                        {
+                            return 0;
+                        }
+                        fragment
+                            .payload
+                            .as_ref()
+                            .map_or_else(|| 0, |payload| payload.data.len())
+                    })
+                    .sum();
+                let mut fragments_iter = fragments.iter();
 
-            row.col(|ui| {
-                ui.label(format_text(
-                    labels.next().unwrap_or_default(),
-                    fragments_iter.next().copied(),
-                ));
-            });
+                row.col(|ui| {
+                    ui.label(format_packet_text(
+                        labels.next().unwrap_or_default(),
+                        fragments_iter.next().copied(),
+                    ));
+                });
 
-            row.col(|ui| {
-                ui.label(format_text(
-                    labels.next().unwrap_or_default(),
-                    fragments_iter.next().copied(),
-                ));
-            });
+                row.col(|ui| {
+                    ui.label(format_packet_text(
+                        labels.next().unwrap_or_default(),
+                        fragments_iter.next().copied(),
+                    ));
+                });
 
-            row.col(|ui| {
-                ui.label(format_text(
-                    labels.next().unwrap_or_default(),
-                    fragments_iter.next().copied(),
-                ));
-            });
+                row.col(|ui| {
+                    ui.label(format_packet_text(
+                        labels.next().unwrap_or_default(),
+                        fragments_iter.next().copied(),
+                    ));
+                });
 
-            row.col(|ui| {
-                ui.label(format_text(
-                    labels.next().unwrap_or_default(),
-                    fragments_iter.next().copied(),
-                ));
-            });
+                row.col(|ui| {
+                    ui.label(format_packet_text(
+                        labels.next().unwrap_or_default(),
+                        fragments_iter.next().copied(),
+                    ));
+                });
 
-            row.col(|ui| {
-                ui.label(format_text(
-                    labels.next().unwrap_or_default(),
-                    fragments_iter.next().copied(),
-                ));
-            });
+                row.col(|ui| {
+                    ui.label(format_packet_text(
+                        labels.next().unwrap_or_default(),
+                        fragments_iter.next().copied(),
+                    ));
+                });
 
-            row.col(|ui| {
-                ui.label(format_text(
-                    labels.next().unwrap_or_default(),
-                    fragments_iter.next().copied(),
-                ));
-            });
+                row.col(|ui| {
+                    ui.label(format_packet_text(
+                        labels.next().unwrap_or_default(),
+                        fragments_iter.next().copied(),
+                    ));
+                });
 
-            row.col(|ui| {
-                ui.label(format_text(
-                    labels.next().unwrap_or_default(),
-                    fragments_iter.next().copied(),
-                ));
-            });
+                row.col(|ui| {
+                    ui.label(format_packet_text(
+                        labels.next().unwrap_or_default(),
+                        fragments_iter.next().copied(),
+                    ));
+                });
 
-            row.col(|ui| {
-                ui.label(payload_size.to_string());
-            });
-        });
+                row.col(|ui| {
+                    ui.label(payload_size.to_string());
+                });
+            },
+        );
     }
-}
-
-fn format_text(value: String, fragment: Option<&MpegtsFragment>) -> RichText {
-    match value {
-        s if s.contains(PAT_FORMAT) => RichText::from(s).color(Color32::GREEN),
-        s if s.contains(PMT_FORMAT) => RichText::from(s).color(Color32::LIGHT_BLUE),
-        s if s.contains(PCR_FORMAT) && s.contains(ES_FORMAT) => {
-            if let Some(fragment) = fragment {
-                RichText::from(format!(
-                    "{}{}",
-                    s,
-                    get_star_according_payload_size(fragment)
-                ))
-            } else {
-                RichText::from(format!("{}", s))
-            }
-        }
-        s => RichText::from(s),
-    }
-}
-
-fn get_star_according_payload_size(fragment: &MpegtsFragment) -> &str {
-    match get_fragment_payload_size(fragment) {
-        1..=183 => "*",
-        _ => "",
-    }
-}
-
-fn get_fragment_payload_size(fragment: &MpegtsFragment) -> usize {
-    if fragment.header.adaptation_field_control == AdaptationFieldControl::AdaptationFieldOnly {
-        return 0;
-    }
-    fragment
-        .payload
-        .as_ref()
-        .map_or(0, |payload| payload.data.len())
 }

--- a/client/src/app/mpegts_packets_table/display.rs
+++ b/client/src/app/mpegts_packets_table/display.rs
@@ -1,0 +1,37 @@
+use egui::Color32;
+use netpix_common::mpegts::{header::AdaptationFieldControl, MpegtsFragment};
+
+pub const PAT_FORMAT: &str = "PAT";
+pub const PMT_FORMAT: &str = "PMT";
+pub const PCR_ES_FORMAT: &str = "PCR+ES";
+pub const ES_FORMAT: &str = "ES";
+pub const PCR_FORMAT: &str = "PCR";
+pub const PID_FORMAT: &str = "PID";
+
+pub fn format_packet_text(value: String, fragment: Option<&MpegtsFragment>) -> egui::RichText {
+    match value {
+        s if s.contains(PAT_FORMAT) => egui::RichText::from(s).color(Color32::GREEN),
+        s if s.contains(PMT_FORMAT) => egui::RichText::from(s).color(Color32::LIGHT_BLUE),
+        s if s.contains(PCR_FORMAT) && s.contains(ES_FORMAT) => format_pcr_es_text(s, fragment),
+        s => egui::RichText::from(s),
+    }
+}
+
+fn format_pcr_es_text(text: String, fragment: Option<&MpegtsFragment>) -> egui::RichText {
+    let suffix = fragment.map_or("", get_star_according_payload_size);
+    egui::RichText::from(format!("{}{}", text, suffix))
+}
+
+fn get_star_according_payload_size(fragment: &MpegtsFragment) -> &'static str {
+    match get_fragment_payload_size(fragment) {
+        1..=183 => "*",
+        _ => "",
+    }
+}
+
+pub fn get_fragment_payload_size(fragment: &MpegtsFragment) -> usize {
+    if fragment.header.adaptation_field_control == AdaptationFieldControl::AdaptationFieldOnly {
+        return 0;
+    }
+    fragment.payload.as_ref().map_or(0, |p| p.data.len())
+}

--- a/client/src/app/mpegts_packets_table/filters.rs
+++ b/client/src/app/mpegts_packets_table/filters.rs
@@ -1,8 +1,8 @@
 use crate::streams::mpegts_stream::MpegTsPacketInfo;
+use log::{log, Level};
 use netpix_common::mpegts::header::{AdaptationFieldControl, PIDTable};
+use std::collections::VecDeque;
 use std::str::FromStr;
-use log::Level::Debug;
-use log::log;
 
 pub trait PacketFilter {
     fn matches(&self, info: &FilterContext) -> bool;
@@ -39,7 +39,9 @@ pub enum PacketType {
 }
 
 pub enum PayloadFilter {
+    GreaterOrEqualThan(usize),
     GreaterThan(usize),
+    LessOrEqualThan(usize),
     LessThan(usize),
     Equals(String),
 }
@@ -86,7 +88,9 @@ impl PacketFilter for FilterType {
                 let payload_size = calculate_payload_size(ctx.packet);
                 match payload_filter {
                     PayloadFilter::GreaterThan(size) => payload_size > *size,
+                    PayloadFilter::GreaterOrEqualThan(size) => payload_size >= *size,
                     PayloadFilter::LessThan(size) => payload_size < *size,
+                    PayloadFilter::LessOrEqualThan(size) => payload_size <= *size,
                     PayloadFilter::Equals(value) => payload_size.to_string().contains(value),
                 }
             }
@@ -116,72 +120,156 @@ impl PacketFilter for FilterType {
     }
 }
 
-pub fn parse_filter(filter: &str) -> Option<FilterType> {
-    parse_or_expression(filter.trim())
+#[derive(Debug, Clone, PartialEq)]
+enum Token {
+    OpenParen,
+    CloseParen,
+    And,
+    Or,
+    Not,
+    Filter(String),
+    Colon,
 }
 
-fn parse_or_expression(input: &str) -> Option<FilterType> {
-    let lower_case = input.trim().to_lowercase();
-    let parts: Vec<&str> = lower_case.split(" or ").collect();
-    if parts.len() == 1 {
-        parse_and_expression(parts[0])
-    } else {
-        parts
-            .into_iter()
-            .map(parse_and_expression)
-            .reduce(|acc, item| Some(FilterType::Or(Box::new(acc?), Box::new(item?))))
-            .flatten()
-    }
+struct Lexer {
+    tokens: VecDeque<Token>,
 }
 
-fn parse_and_expression(input: &str) -> Option<FilterType> {
-    let lower_case = input.trim().to_lowercase();
-    let parts: Vec<&str> = lower_case.split(" and ").collect();
-    if parts.len() == 1 {
-        parse_not_expression(parts[0])
-    } else {
-        parts
-            .into_iter()
-            .map(parse_not_expression)
-            .reduce(|acc, item| Some(FilterType::And(Box::new(acc?), Box::new(item?))))
-            .flatten()
-    }
-}
+impl Lexer {
+    fn new(input: &str) -> Self {
+        let mut tokens = VecDeque::new();
+        let mut chars = input.chars().peekable();
+        let mut current = String::new();
 
-fn parse_not_expression(input: &str) -> Option<FilterType> {
-    let lower_case = input.trim().to_lowercase();
-    if lower_case.starts_with("not ") {
-        let inner = parse_basic_filter(&input[4..])?;
-        Some(FilterType::Not(Box::new(inner)))
-    } else {
-        parse_basic_filter(input)
-    }
-}
-
-fn parse_basic_filter(input: &str) -> Option<FilterType> {
-    let input = input.trim();
-    if input.starts_with('(') && input.ends_with(')') {
-        return parse_or_expression(&input[1..input.len() - 1]);
-    }
-
-    if let Some((prefix, value)) = input.split_once(':') {
-        let value = value.trim().to_lowercase();
-        match prefix.trim() {
-            "desc" => Some(FilterType::Description(value)),
-            "source" => Some(FilterType::Source(value)),
-            "dest" => Some(FilterType::Destination(value)),
-            "alias" => Some(FilterType::Alias(value)),
-            "payload" => parse_payload_filter(&value),
-            p if p.starts_with('p') && p.len() == 2 => {
-                let packet_index = p[1..].parse::<usize>().ok()?.saturating_sub(1);
-                Some(FilterType::PacketPID(packet_index, value))
+        while let Some(c) = chars.next() {
+            match c {
+                '(' => {
+                    Self::push_if_not_empty(&mut tokens, &mut current);
+                    tokens.push_back(Token::OpenParen);
+                }
+                ')' => {
+                    Self::push_if_not_empty(&mut tokens, &mut current);
+                    tokens.push_back(Token::CloseParen);
+                }
+                ':' => {
+                    Self::push_if_not_empty(&mut tokens, &mut current);
+                    tokens.push_back(Token::Colon);
+                }
+                ' ' => {
+                    if !current.is_empty() {
+                        match current.to_lowercase().as_str() {
+                            "and" => tokens.push_back(Token::And),
+                            "or" => tokens.push_back(Token::Or),
+                            "not" => tokens.push_back(Token::Not),
+                            _ => tokens.push_back(Token::Filter(current.clone())),
+                        }
+                        current.clear();
+                    }
+                }
+                _ => current.push(c),
             }
-            "pid" => value.parse().ok().map(FilterType::PID),
-            "type" => PacketType::from_str(&value).ok().map(FilterType::Type),
-            _ => None,
         }
-    } else {
-        None
+        Self::push_if_not_empty(&mut tokens, &mut current);
+        Self { tokens }
+    }
+
+    fn push_if_not_empty(tokens: &mut VecDeque<Token>, current: &mut String) {
+        if !current.is_empty() {
+            tokens.push_back(Token::Filter(current.clone()));
+            current.clear();
+        }
+    }
+
+    fn next_token(&mut self) -> Option<Token> {
+        self.tokens.pop_front()
+    }
+
+    fn peek_token(&self) -> Option<&Token> {
+        self.tokens.front()
+    }
+}
+
+pub fn parse_filter(filter: &str) -> Option<FilterType> {
+    let mut lexer = Lexer::new(filter);
+    parse_expression(&mut lexer, 0)
+}
+
+fn parse_expression(lexer: &mut Lexer, precedence: u8) -> Option<FilterType> {
+    let mut left = parse_primary(lexer)?;
+
+    while let Some(token) = lexer.peek_token() {
+        let current_precedence = get_operator_precedence(token);
+        if current_precedence < precedence {
+            break;
+        }
+
+        match token {
+            Token::And => {
+                lexer.next_token(); // consume AND
+                let right = parse_expression(lexer, current_precedence + 1)?;
+                left = FilterType::And(Box::new(left), Box::new(right));
+            }
+            Token::Or => {
+                lexer.next_token(); // consume OR
+                let right = parse_expression(lexer, current_precedence + 1)?;
+                left = FilterType::Or(Box::new(left), Box::new(right));
+            }
+            _ => break,
+        }
+    }
+
+    Some(left)
+}
+
+fn parse_primary(lexer: &mut Lexer) -> Option<FilterType> {
+    match lexer.next_token()? {
+        Token::OpenParen => {
+            let expr = parse_expression(lexer, 0)?;
+            if lexer.next_token() != Some(Token::CloseParen) {
+                return None;
+            }
+            Some(expr)
+        }
+        Token::Not => {
+            let expr = parse_primary(lexer)?;
+            Some(FilterType::Not(Box::new(expr)))
+        }
+        Token::Filter(prefix) => {
+            if lexer.next_token() != Some(Token::Colon) {
+                return None;
+            }
+            if let Some(Token::Filter(value)) = lexer.next_token() {
+                parse_filter_with_value(&prefix, &value)
+            } else {
+                None
+            }
+        }
+        _ => None,
+    }
+}
+
+fn get_operator_precedence(token: &Token) -> u8 {
+    match token {
+        Token::Or => 1,
+        Token::And => 2,
+        _ => 0,
+    }
+}
+
+fn parse_filter_with_value(prefix: &str, value: &str) -> Option<FilterType> {
+    match prefix.trim() {
+        "desc" => Some(FilterType::Description(value.to_string())),
+        "source" => Some(FilterType::Source(value.to_lowercase())),
+        "dest" => Some(FilterType::Destination(value.to_lowercase())),
+        "alias" => Some(FilterType::Alias(value.to_lowercase())),
+        "payload" => parse_payload_filter(value),
+        p if p.starts_with('p') && p.len() == 2 => {
+            let packet_index = p[1..].parse::<usize>().ok()?.saturating_sub(1);
+            Some(FilterType::PacketPID(packet_index, value.to_string()))
+        }
+        "pid" => value.parse().ok().map(FilterType::PID),
+        "type" => PacketType::from_str(value).ok().map(FilterType::Type),
+        _ => None,
     }
 }
 
@@ -192,6 +280,18 @@ fn parse_payload_filter(value: &str) -> Option<FilterType> {
             .parse()
             .ok()
             .map(PayloadFilter::GreaterThan)
+    } else if value.starts_with("=>") {
+        value[2..]
+            .trim()
+            .parse()
+            .ok()
+            .map(PayloadFilter::GreaterOrEqualThan)
+    } else if value.starts_with("<=") {
+        value[2..]
+            .trim()
+            .parse()
+            .ok()
+            .map(PayloadFilter::LessOrEqualThan)
     } else if value.starts_with('<') {
         value[1..].trim().parse().ok().map(PayloadFilter::LessThan)
     } else {

--- a/client/src/app/mpegts_packets_table/types.rs
+++ b/client/src/app/mpegts_packets_table/types.rs
@@ -1,0 +1,27 @@
+use crate::streams::mpegts_stream::MpegTsPacketInfo;
+use netpix_common::MpegtsStreamKey;
+use web_time::Duration;
+
+#[derive(Clone)]
+pub struct PacketInfo<'a> {
+    pub packet: &'a MpegTsPacketInfo,
+    pub timestamp: Duration,
+    pub key: MpegtsStreamKey,
+}
+
+#[derive(Debug, Clone)]
+pub struct TableConfig {
+    pub row_height: f32,
+    pub header_height: f32,
+    pub space_after_filter: f32,
+}
+
+impl Default for TableConfig {
+    fn default() -> Self {
+        Self {
+            row_height: 25.0,
+            header_height: 30.0,
+            space_after_filter: 5.0,
+        }
+    }
+}

--- a/client/src/app/packets_table.rs
+++ b/client/src/app/packets_table.rs
@@ -36,7 +36,7 @@ impl PacketsTable {
             .hint_text("Apply a filter ...");
 
         ui.horizontal(|ui| {
-            // TODO: implement the actuall filtering
+            // TODO: implement the actual filtering
             ui.button("↻").on_hover_text("Reset the filter");
             ui.button("⏵").on_hover_text("Apply the filter");
             ui.add(text_edit);

--- a/client/src/app/rtcp_packets_table.rs
+++ b/client/src/app/rtcp_packets_table.rs
@@ -120,7 +120,7 @@ fn get_row_height(packet: &RtcpPacket) -> f32 {
                 .iter()
                 .map(|chunk| chunk.items.len() + 1)
                 .max()
-                // AFAIR, 0 chunk SDES packet is possible, although useless
+                // AFFAIR, 0 chunk SDES packet is possible, although useless
                 .unwrap_or(1) as f32
         }
         RtcpPacket::ReceiverReport(rr) => match rr.reports.len() {

--- a/client/src/app/rtp_streams_plot.rs
+++ b/client/src/app/rtp_streams_plot.rs
@@ -46,12 +46,12 @@ struct StreamText {
 enum SettingsXAxis {
     RtpTimestamp,
     RawTimestamp,
-    SequenceNumer,
+    SequenceNumber,
 }
 
 impl SettingsXAxis {
     fn all() -> Vec<Self> {
-        vec![RtpTimestamp, RawTimestamp, SequenceNumer]
+        vec![RtpTimestamp, RawTimestamp, SequenceNumber]
     }
 }
 
@@ -60,7 +60,7 @@ impl Display for SettingsXAxis {
         let name = match self {
             RtpTimestamp => "RTP timestamp",
             RawTimestamp => "Seconds from start",
-            SequenceNumer => "Sequence number",
+            SequenceNumber => "Sequence number",
         };
 
         write!(f, "{}", name)
@@ -179,7 +179,7 @@ impl RtpStreamsPlot {
         let (x_min_text, x_max_text) = match self.x_axis {
             RtpTimestamp => ("First RTP timestamp", "Length"),
             RawTimestamp => ("First second", "Length"),
-            SequenceNumer => ("First sequence number", "Length"),
+            SequenceNumber => ("First sequence number", "Length"),
         };
 
         let max = (self.slider_max as f64 * 1.13) as i64;
@@ -276,7 +276,7 @@ impl RtpStreamsPlot {
     }
 
     fn draw_points(&mut self, plot_ui: &mut PlotUi) {
-        let mut heighest_y = 0.0;
+        let mut highest_y = 0.0;
         for point_data in &self.points_data {
             let PointData {
                 x,
@@ -288,8 +288,8 @@ impl RtpStreamsPlot {
                 is_rtcp,
                 marker_shape,
             } = point_data;
-            if *y_top > heighest_y {
-                heighest_y = *y_top;
+            if *y_top > highest_y {
+                highest_y = *y_top;
             }
 
             let point = Points::new([*x, *y_top])
@@ -337,7 +337,7 @@ impl RtpStreamsPlot {
                 [(self.slider_start as f64) - 0.05, -0.5],
                 [
                     (self.slider_start + self.slider_length) as f64,
-                    heighest_y * 1.55,
+                    highest_y * 1.55,
                 ],
             ));
             self.set_plot_bounds = false
@@ -374,7 +374,7 @@ impl RtpStreamsPlot {
                     RawTimestamp => {
                         rtp_packet.time.as_secs_f64() - first_packet.timestamp.as_secs_f64()
                     }
-                    SequenceNumer => {
+                    SequenceNumber => {
                         rtp_packet.packet.sequence_number as f64
                             - first_rtp_packet.sequence_number as f64
                     }
@@ -411,7 +411,7 @@ impl RtpStreamsPlot {
                 let this_stream_y_baseline = match self.x_axis {
                     RtpTimestamp => previous_stream_max_y + biggest_margin,
                     RawTimestamp => previous_stream_max_y + 20.0,
-                    SequenceNumer => previous_stream_max_y + 20.0,
+                    SequenceNumber => previous_stream_max_y + 20.0,
                 };
                 self.stream_texts.push(StreamText {
                     x: 0.0,
@@ -614,7 +614,7 @@ fn build_stream_points(
                             *slider_max = x;
                         }
                     }
-                    SequenceNumer => {}
+                    SequenceNumber => {}
                 }
             }
         }
@@ -729,7 +729,7 @@ fn get_x_and_y(
             this_stream_y_baseline,
             this_stream_y_baseline + height,
         ),
-        SequenceNumer => (
+        SequenceNumber => (
             (rtp.packet.sequence_number - first_rtp_packet.sequence_number) as f64,
             this_stream_y_baseline,
             this_stream_y_baseline + height,
@@ -793,7 +793,7 @@ fn build_on_hover_text(
     let str = match settings_x_axis {
         RtpTimestamp => format!("x = {} [RTP timestamp]\n", x),
         RawTimestamp => format!("x = {:.5} [s]\n", x),
-        SequenceNumer => format!("x = {} [Sequence number]\n", x),
+        SequenceNumber => format!("x = {} [Sequence number]\n", x),
     };
     on_hover.push_str(&str);
     on_hover

--- a/client/src/app/tab.rs
+++ b/client/src/app/tab.rs
@@ -17,7 +17,7 @@ pub enum RtpSection {
 pub enum MpegTsSection {
     MpegTsPackets,
     MpegTsStreams,
-    MpegTsInformations,
+    MpegTsInformation,
     MpegTsPlot,
 }
 
@@ -31,7 +31,7 @@ impl Tab {
             Self::RtpSection(RtpSection::RtpPlot),
             Self::MpegTsSection(MpegTsSection::MpegTsPackets),
             Self::MpegTsSection(MpegTsSection::MpegTsStreams),
-            Self::MpegTsSection(MpegTsSection::MpegTsInformations),
+            Self::MpegTsSection(MpegTsSection::MpegTsInformation),
             Self::MpegTsSection(MpegTsSection::MpegTsPlot),
         ]
     }
@@ -56,7 +56,7 @@ impl fmt::Display for Tab {
             Self::MpegTsSection(section) => match section {
                 MpegTsSection::MpegTsPackets => "📺 MPEG-TS Packets",
                 MpegTsSection::MpegTsStreams => "🎥 MPEG-TS Streams",
-                MpegTsSection::MpegTsInformations => "ℹ️ MPEG-TS Info",
+                MpegTsSection::MpegTsInformation => "ℹ️ MPEG-TS Info",
                 MpegTsSection::MpegTsPlot => "📊 MPEG-TS Plot",
             },
         };

--- a/client/src/streams/rtpStream.rs
+++ b/client/src/streams/rtpStream.rs
@@ -172,7 +172,7 @@ impl RtpStream {
                     // revisit_packets = true;
                 }
                 // self.ntp_rtp = Some((sr.ntp_time, sr.rtp_time));
-                // TODO: use the estiamted clock rate to set ntp time in rtp_info
+                // TODO: use the estimated clock rate to set ntp time in rtp_info
                 // TODO: sometimes ntp timestamps are bs
             }
             _ => {}

--- a/common/src/mpegts/psi/pat/fragmentary_pat.rs
+++ b/common/src/mpegts/psi/pat/fragmentary_pat.rs
@@ -58,7 +58,7 @@ impl FragmentaryPsi for FragmentaryProgramAssociationTable {
         if data.len() < HEADER_SIZE {
             return None;
         }
-        //TODO FIX: we are not taking into account last bytes of the previous section which resides imediately after ---> pointer_field | end of section n + 1 | new table_id | payload | ...
+        //TODO FIX: we are not taking into account last bytes of the previous section which resides immediately after ---> pointer_field | end of section n + 1 | new table_id | payload | ...
         // https://tsduck.io/download/docs/mpegts-introduction.pdf - more details in section `Typical section packetization`
         let data = if is_pointer_field {
             &data[data[0] as usize + 1..]

--- a/src/cmd/list.rs
+++ b/src/cmd/list.rs
@@ -8,7 +8,7 @@ pub struct List {}
 impl List {
     pub async fn run(self) {
         Device::list()
-            .expect("Error occured while listing devices")
+            .expect("Error occurred while listing devices")
             .iter()
             .filter(|device| {
                 (device.flags.if_flags.contains(IfFlags::UP) && !device.addresses.is_empty())

--- a/src/server.rs
+++ b/src/server.rs
@@ -202,7 +202,7 @@ async fn send_all_packets(
     }
 
     info!(
-        "Sucesfully send already captured packets, client_id: {}",
+        "Successfully send already captured packets, client_id: {}",
         client_id
     );
 }


### PR DESCRIPTION
This pull request includes significant updates to the `client/src/app/mpegts_packets_table.rs` file, focusing on refactoring and improving the code structure, as well as adding new features for packet filtering and display formatting.

### Refactoring and Code Organization:
* Split the `mpegts_packets_table.rs` file into multiple modules: `display`, `filters`, and `types` for better code organization.
* Moved constants and functions related to packet text formatting to the new `display.rs` module.

### Feature Enhancements:
* Added a new filtering feature with the `build_filter` method to allow users to filter packets based on various criteria.
* Introduced a `TableConfig` struct to manage table configuration settings such as row height and header height, and updated the table building process to use these settings.

### Dependency Updates:
* Updated the `wasm-bindgen-futures` dependency version in `Cargo.toml` from `0.4` to `0.4.45`.

### Code Clean-up:
* Removed unused imports and restructured import statements for better clarity.
* Removed redundant constants and inlined the `streams_visibility` hashmap within the `MpegTsPacketsTable` struct.

These changes collectively enhance the maintainability, readability, and functionality of the `mpegts_packets_table` module.