### PR TITLE
Change serde to bincode 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -115,11 +115,21 @@ checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
 name = "bincode"
-version = "1.3.3"
+version = "2.0.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+checksum = "f11ea1a0346b94ef188834a65c068a03aec181c94896d481d7a0a40d85b0ce95"
 dependencies = [
+ "bincode_derive",
  "serde",
+]
+
+[[package]]
+name = "bincode_derive"
+version = "2.0.0-rc.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e30759b3b99a1b802a7a3aa21c85c3ded5c28e1c83170d82d70f08bbf7f3e4c"
+dependencies = [
+ "virtue",
 ]
 
 [[package]]
@@ -1760,6 +1770,12 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "virtue"
+version = "0.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dcc60c0624df774c82a0ef104151231d37da4962957d691c011c852b2473314"
 
 [[package]]
 name = "walkdir"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ clap = { version = "4", features = ["derive"] }
 rust-embed = "8.0.0"
 mime_guess = "2.0.4"
 ringbuf = "0.4.7"
-bincode = "1.3"
+bincode = "=2.0.0-rc.3"
 bon = "3.3.0"
 flate2 = "1.0.35"
 

--- a/client/Cargo.lock
+++ b/client/Cargo.lock
@@ -186,11 +186,21 @@ checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "bincode"
-version = "1.3.3"
+version = "2.0.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+checksum = "f11ea1a0346b94ef188834a65c068a03aec181c94896d481d7a0a40d85b0ce95"
 dependencies = [
+ "bincode_derive",
  "serde",
+]
+
+[[package]]
+name = "bincode_derive"
+version = "2.0.0-rc.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e30759b3b99a1b802a7a3aa21c85c3ded5c28e1c83170d82d70f08bbf7f3e4c"
+dependencies = [
+ "virtue",
 ]
 
 [[package]]
@@ -2518,6 +2528,12 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "virtue"
+version = "0.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dcc60c0624df774c82a0ef104151231d37da4962957d691c011c852b2473314"
 
 [[package]]
 name = "walkdir"

--- a/client/src/app/types.rs
+++ b/client/src/app/types.rs
@@ -114,11 +114,11 @@ impl App {
             };
 
             match response {
-                Response::Packet(packet) => {
+                (Response::Packet(packet), _) => {
                     let mut streams = self.streams.borrow_mut();
                     streams.add_packet(packet);
                 }
-                Response::Sources(sources) => {
+                (Response::Sources(sources), _) => {
                     if let Some(ref source) = self.selected_source {
                         if !sources.contains(source) {
                             self.selected_source = None;
@@ -128,13 +128,13 @@ impl App {
                     }
                     self.sources = sources;
                 }
-                Response::Sdp(stream_key, sdp) => {
+                (Response::Sdp(stream_key, sdp), _) => {
                     let mut streams = self.streams.borrow_mut();
                     if let Some(stream) = streams.rtp_streams.get_mut(&stream_key) {
                         stream.add_sdp(sdp);
                     }
                 }
-                Response::PacketsStats(stats) => {
+                (Response::PacketsStats(stats), _) => {
                     self.discharged_count = stats.discharged;
                     self.overwritten_count = stats.overwritten;
                 }

--- a/common/Cargo.lock
+++ b/common/Cargo.lock
@@ -60,11 +60,21 @@ dependencies = [
 
 [[package]]
 name = "bincode"
-version = "1.3.3"
+version = "2.0.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+checksum = "f11ea1a0346b94ef188834a65c068a03aec181c94896d481d7a0a40d85b0ce95"
 dependencies = [
+ "bincode_derive",
  "serde",
+]
+
+[[package]]
+name = "bincode_derive"
+version = "2.0.0-rc.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e30759b3b99a1b802a7a3aa21c85c3ded5c28e1c83170d82d70f08bbf7f3e4c"
+dependencies = [
+ "virtue",
 ]
 
 [[package]]
@@ -872,6 +882,12 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "virtue"
+version = "0.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dcc60c0624df774c82a0ef104151231d37da4962957d691c011c852b2473314"
 
 [[package]]
 name = "wasi"

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -10,7 +10,7 @@ readme = false
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
-bincode = "1.3"
+bincode = "=2.0.0-rc.3"
 log = "0.4.20"
 flate2 = "1.0.35"
 

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -1,4 +1,8 @@
-use serde::{Deserialize, Serialize};
+use bincode::{
+    config,
+    error::{DecodeError, EncodeError},
+    Decode, Encode,
+};
 use std::fmt;
 
 pub use crate::mpegts::MpegtsPacket;
@@ -19,7 +23,7 @@ pub use stream_keys::{MpegtsStreamKey, PacketAssociationTable, RtpStreamKey};
 
 pub const PACKET_MAX_AGE_SECS: u64 = 120; // 2 minutes
 
-#[derive(Serialize, Deserialize, Debug, Clone, Hash, Eq, PartialEq)]
+#[derive(Decode, Encode, Debug, Clone, Hash, Eq, PartialEq)]
 pub enum Source {
     File(String),
     Interface(String),
@@ -54,7 +58,7 @@ impl fmt::Display for Source {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Encode, Decode, Debug, Clone)]
 pub enum Request {
     FetchAll,
     Reparse(usize, packet::SessionProtocol),
@@ -63,13 +67,13 @@ pub enum Request {
     PacketsStats(PacketsStats),
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Decode, Encode, Debug, Clone)]
 pub struct PacketsStats {
     pub discharged: usize,
     pub overwritten: usize,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Decode, Encode, Debug, Clone)]
 pub enum Response {
     Packet(Packet),
     Sources(Vec<Source>),
@@ -78,21 +82,21 @@ pub enum Response {
 }
 
 impl Request {
-    pub fn decode(bytes: &[u8]) -> Result<Self, bincode::Error> {
-        bincode::deserialize(bytes)
+    pub fn decode(bytes: &[u8]) -> Result<(Self, usize), DecodeError> {
+        bincode::decode_from_slice(bytes, config::standard())
     }
 
-    pub fn encode(&self) -> Result<Vec<u8>, bincode::Error> {
-        bincode::serialize(self)
+    pub fn encode(&self) -> Result<Vec<u8>, EncodeError> {
+        bincode::encode_to_vec(self, config::standard())
     }
 }
 
 impl Response {
-    pub fn decode(bytes: &[u8]) -> Result<Self, bincode::Error> {
-        bincode::deserialize(bytes)
+    pub fn decode(bytes: &[u8]) -> Result<(Self, usize), DecodeError> {
+        bincode::decode_from_slice(bytes, config::standard())
     }
 
-    pub fn encode(&self) -> Result<Vec<u8>, bincode::Error> {
-        bincode::serialize(self)
+    pub fn encode(&self) -> Result<Vec<u8>, EncodeError> {
+        bincode::encode_to_vec(self, config::standard())
     }
 }

--- a/common/src/mpegts.rs
+++ b/common/src/mpegts.rs
@@ -16,15 +16,15 @@ use crate::mpegts::header::{AdaptationFieldControl, PIDTable, TransportScramblin
 use crate::mpegts::payload::RawPayload;
 use crate::utils::bits::BitReader;
 use constants::*;
-use serde::{Deserialize, Serialize};
+use bincode::{Decode, Encode};
 
-#[derive(Serialize, Deserialize, Debug, Clone, Eq, PartialEq)]
+#[derive(Decode, Encode, Debug, Clone, Eq, PartialEq)]
 pub struct MpegtsPacket {
     pub number_of_fragments: usize,
     pub fragments: Vec<MpegtsFragment>,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, Eq, PartialEq)]
+#[derive(Decode, Encode, Debug, Clone, Eq, PartialEq)]
 pub struct MpegtsFragment {
     pub header: Header,
     pub adaptation_field: Option<AdaptationField>,

--- a/common/src/mpegts/adaptation_field.rs
+++ b/common/src/mpegts/adaptation_field.rs
@@ -1,10 +1,10 @@
 use crate::utils::bits::BitReader;
-use serde::{Deserialize, Serialize};
+use bincode::{Decode, Encode};
 
 const STUFFING_BYTE: u8 = 0xFF;
 const LTW_OFFSET_MASK: u8 = 0x7F;
 
-#[derive(Default, Serialize, Deserialize, Debug, Clone, Eq, PartialEq)]
+#[derive(Default, Decode, Encode, Debug, Clone, Eq, PartialEq)]
 pub struct AdaptationField {
     pub adaptation_field_length: u8,
     pub discontinuity_indicator: bool,
@@ -26,7 +26,7 @@ pub struct AdaptationField {
     pub number_of_stuffing_bytes: Option<u8>,
 }
 
-#[derive(Default, Serialize, Deserialize, Debug, Clone, Eq, PartialEq)]
+#[derive(Default, Decode, Encode, Debug, Clone, Eq, PartialEq)]
 pub struct AdaptationFieldExtension {
     pub adaptation_field_extension_length: u8,
     pub ltw_flag: bool,

--- a/common/src/mpegts/aggregator.rs
+++ b/common/src/mpegts/aggregator.rs
@@ -8,10 +8,10 @@ use crate::mpegts::psi::pat::ProgramAssociationTable;
 use crate::mpegts::psi::pmt::ProgramMapTable;
 use crate::mpegts::MpegtsFragment;
 use crate::utils::traits::BufferOperations;
-use serde::{Deserialize, Serialize};
+use bincode::{Decode, Encode};
 use std::collections::HashMap;
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Decode, Encode, Debug, Clone)]
 pub struct MpegtsAggregator {
     pub pat_buffer: PatBuffer,
     pub pmt_buffers: HashMap<u16, PmtBuffer>,

--- a/common/src/mpegts/descriptors.rs
+++ b/common/src/mpegts/descriptors.rs
@@ -39,7 +39,7 @@ use crate::{
 use crate::{
     impl_descriptor_display, impl_descriptor_partial_eq, impl_descriptor_unmarshall_match,
 };
-use serde::{Deserialize, Serialize};
+use bincode::{Decode, Encode};
 use std::fmt::Debug;
 
 const HEADER_SIZE: u8 = 2;
@@ -126,7 +126,7 @@ impl_descriptor_partial_eq! {
     (Iso639LanguageDescriptor),
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, Ord, PartialOrd, Eq)]
+#[derive(Decode, Encode, Debug, Clone, Ord, PartialOrd, Eq)]
 pub struct DescriptorHeader {
     pub descriptor_tag: DescriptorTag,
     pub descriptor_length: u8,

--- a/common/src/mpegts/descriptors/avc_video_descriptor.rs
+++ b/common/src/mpegts/descriptors/avc_video_descriptor.rs
@@ -1,7 +1,7 @@
 use crate::implement_descriptor;
 use crate::mpegts::descriptors::{DescriptorHeader, ParsableDescriptor};
 use crate::utils::bits::BitReader;
-use serde::{Deserialize, Serialize};
+use bincode::{Decode, Encode};
 
 const AVC_COMPATIBLE_FLAGS_MASK: u8 = 0b0000_0011;
 

--- a/common/src/mpegts/descriptors/ca_descriptor.rs
+++ b/common/src/mpegts/descriptors/ca_descriptor.rs
@@ -1,7 +1,7 @@
 use crate::implement_descriptor;
 use crate::mpegts::descriptors::{DescriptorHeader, ParsableDescriptor};
 use crate::utils::bits::BitReader;
-use serde::{Deserialize, Serialize};
+use bincode::{Decode, Encode};
 
 const CA_PID_MASK: u8 = 0b0001_1111;
 

--- a/common/src/mpegts/descriptors/copyright_descriptor.rs
+++ b/common/src/mpegts/descriptors/copyright_descriptor.rs
@@ -1,7 +1,7 @@
 use crate::implement_descriptor;
 use crate::mpegts::descriptors::{DescriptorHeader, ParsableDescriptor};
 use crate::utils::bits::BitReader;
-use serde::{Deserialize, Serialize};
+use bincode::{Decode, Encode};
 
 implement_descriptor! {
     pub struct CopyrightDescriptor {

--- a/common/src/mpegts/descriptors/data_stream_alignment_descriptor.rs
+++ b/common/src/mpegts/descriptors/data_stream_alignment_descriptor.rs
@@ -1,7 +1,7 @@
 use crate::implement_descriptor;
 use crate::mpegts::descriptors::{DescriptorHeader, ParsableDescriptor};
 use crate::utils::bits::BitReader;
-use serde::{Deserialize, Serialize};
+use bincode::{Decode, Encode};
 
 implement_descriptor! {
     pub struct DataStreamAlignmentDescriptor {
@@ -23,7 +23,7 @@ implement_descriptor! {
 }
 
 // TODO: for PES is other table 2.54 when data_alignment_indicator is set
-#[derive(Serialize, Deserialize, Debug, Clone, Ord, PartialOrd, Eq)]
+#[derive(Decode, Encode, Debug, Clone, Ord, PartialOrd, Eq)]
 pub enum AlignmentType {
     Reserved,
     Slice,

--- a/common/src/mpegts/descriptors/hierarchy.rs
+++ b/common/src/mpegts/descriptors/hierarchy.rs
@@ -1,7 +1,7 @@
 use crate::implement_descriptor;
 use crate::mpegts::descriptors::{DescriptorHeader, ParsableDescriptor};
 use crate::utils::bits::BitReader;
-use serde::{Deserialize, Serialize};
+use bincode::{Decode, Encode};
 
 const HIERARCHY_TYPE: u8 = 0b0000_1111;
 
@@ -56,7 +56,7 @@ implement_descriptor! {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, Ord, PartialOrd, Eq)]
+#[derive(Decode, Encode, Debug, Clone, Ord, PartialOrd, Eq)]
 pub enum HierarchyType {
     Reserved,
     SpatialScalability,

--- a/common/src/mpegts/descriptors/iso_639_language_descriptor.rs
+++ b/common/src/mpegts/descriptors/iso_639_language_descriptor.rs
@@ -3,17 +3,17 @@ use std::fmt;
 use crate::implement_descriptor;
 use crate::mpegts::descriptors::{DescriptorHeader, ParsableDescriptor};
 use crate::utils::bits::BitReader;
-use serde::{Deserialize, Serialize};
+use bincode::{Decode, Encode};
 
 const SECTION_LENGTH: u8 = 4;
 
-#[derive(Serialize, Deserialize, Debug, Clone, Ord, PartialOrd, Eq)]
+#[derive(Decode, Encode, Debug, Clone, Ord, PartialOrd, Eq)]
 pub struct Section {
     pub language_code: String,
     pub audio_type: AudioType,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, Ord, PartialOrd, Eq)]
+#[derive(Decode, Encode, Debug, Clone, Ord, PartialOrd, Eq)]
 pub enum AudioType {
     Undefined,
     CleanEffects,

--- a/common/src/mpegts/descriptors/macros.rs
+++ b/common/src/mpegts/descriptors/macros.rs
@@ -1,7 +1,7 @@
 #[macro_export]
 macro_rules! declare_descriptor_variants {
     ($(($variant:ident, $type:ty)),* $(,)?) => {
-        #[derive(Serialize, Deserialize, Debug, Clone, Ord, PartialOrd, Eq)]
+        #[derive(Decode, Encode, Debug, Clone, Ord, PartialOrd, Eq)]
         pub enum Descriptors {
             $($variant($type),)*
             UserPrivate(u8),
@@ -93,7 +93,7 @@ macro_rules! implement_descriptor {
         $(,)?
     ) => {
         $(#[$struct_meta])*
-        #[derive(serde::Serialize, serde::Deserialize, Debug, Clone, Ord, PartialOrd, Eq)]
+        #[derive(bincode::Encode, bincode::Decode, Debug, Clone, Ord, PartialOrd, Eq)]
         $vis struct $name {
             pub header: $crate::mpegts::descriptors::DescriptorHeader,
             $(
@@ -170,7 +170,7 @@ macro_rules! implement_descriptor {
         $(,)?
     ) => {
         $(#[$struct_meta])*
-        #[derive(serde::Serialize, serde::Deserialize, Debug, Clone, Ord, PartialOrd, Eq)]
+        #[derive(bincode::Encode, bincode::Decode, Debug, Clone, Ord, PartialOrd, Eq)]
         $vis struct $name {
             pub header: $crate::mpegts::descriptors::DescriptorHeader,
             $(

--- a/common/src/mpegts/descriptors/maximum_bitrate_descriptor.rs
+++ b/common/src/mpegts/descriptors/maximum_bitrate_descriptor.rs
@@ -1,7 +1,7 @@
 use crate::implement_descriptor;
 use crate::mpegts::descriptors::{DescriptorHeader, ParsableDescriptor};
 use crate::utils::bits::BitReader;
-use serde::{Deserialize, Serialize};
+use bincode::{Decode, Encode};
 
 const MAXIMUM_BITRATE: u8 = 0b00111111;
 const BITRATE_PER_SECOND: u32 = 50;

--- a/common/src/mpegts/descriptors/multiplex_buffer_utilization_descriptor.rs
+++ b/common/src/mpegts/descriptors/multiplex_buffer_utilization_descriptor.rs
@@ -1,7 +1,7 @@
 use crate::implement_descriptor;
 use crate::mpegts::descriptors::{DescriptorHeader, ParsableDescriptor};
 use crate::utils::bits::BitReader;
-use serde::{Deserialize, Serialize};
+use bincode::{Decode, Encode};
 
 const LTW_OFFSET_MASK: u8 = 0b0111_1111;
 

--- a/common/src/mpegts/descriptors/private_data_indicator_descriptor.rs
+++ b/common/src/mpegts/descriptors/private_data_indicator_descriptor.rs
@@ -1,7 +1,7 @@
 use crate::implement_descriptor;
 use crate::mpegts::descriptors::{DescriptorHeader, ParsableDescriptor};
 use crate::utils::bits::BitReader;
-use serde::{Deserialize, Serialize};
+use bincode::{Decode, Encode};
 
 implement_descriptor! {
     pub struct PrivateDataIndicatorDescriptor {

--- a/common/src/mpegts/descriptors/registration_descriptor.rs
+++ b/common/src/mpegts/descriptors/registration_descriptor.rs
@@ -1,7 +1,7 @@
 use crate::implement_descriptor;
 use crate::mpegts::descriptors::{DescriptorHeader, ParsableDescriptor};
 use crate::utils::bits::BitReader;
-use serde::{Deserialize, Serialize};
+use bincode::{Decode, Encode};
 
 implement_descriptor! {
     pub struct RegistrationDescriptor {

--- a/common/src/mpegts/descriptors/std_descriptor.rs
+++ b/common/src/mpegts/descriptors/std_descriptor.rs
@@ -1,7 +1,7 @@
 use crate::implement_descriptor;
 use crate::mpegts::descriptors::{DescriptorHeader, ParsableDescriptor};
 use crate::utils::bits::BitReader;
-use serde::{Deserialize, Serialize};
+use bincode::{Decode, Encode};
 
 const LEAK_VALID_FLAG: u8 = 0b0000_0001;
 

--- a/common/src/mpegts/descriptors/tags.rs
+++ b/common/src/mpegts/descriptors/tags.rs
@@ -1,6 +1,6 @@
-use serde::{Deserialize, Serialize};
+use bincode::{Decode, Encode};
 
-#[derive(Serialize, Deserialize, Debug, Clone, Ord, PartialOrd, Eq, Default)]
+#[derive(Decode, Encode, Debug, Clone, Ord, PartialOrd, Eq, Default)]
 pub enum DescriptorTag {
     VideoStreamDescriptorTag,
     AudioStreamDescriptorTag,

--- a/common/src/mpegts/descriptors/video_window_descriptor.rs
+++ b/common/src/mpegts/descriptors/video_window_descriptor.rs
@@ -1,7 +1,7 @@
 use crate::implement_descriptor;
 use crate::mpegts::descriptors::{DescriptorHeader, ParsableDescriptor};
 use crate::utils::bits::BitReader;
-use serde::{Deserialize, Serialize};
+use bincode::{Decode, Encode};
 
 const HORIZONTAL_OFFSET_MASK: u8 = 0b1111_1100;
 const VERTICAL_OFFSET_UP_MASK: u8 = 0b1100_0000;

--- a/common/src/mpegts/header.rs
+++ b/common/src/mpegts/header.rs
@@ -1,6 +1,6 @@
-use serde::{Deserialize, Serialize};
+use bincode::{Decode, Encode};
 
-#[derive(Serialize, Deserialize, Debug, Clone, Eq, PartialEq, Default)]
+#[derive(Decode, Encode, Debug, Clone, Eq, PartialEq, Default)]
 pub struct Header {
     pub transport_error_indicator: bool,
     pub payload_unit_start_indicator: bool,
@@ -12,7 +12,7 @@ pub struct Header {
 }
 
 #[derive(
-    Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq, Hash, Default, Ord, PartialOrd,
+    Decode, Encode, Debug, Clone, Copy, PartialEq, Eq, Hash, Default, Ord, PartialOrd,
 )]
 pub enum PIDTable {
     #[default]
@@ -25,14 +25,14 @@ pub enum PIDTable {
     NullPacket,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, Eq, PartialEq, Default)]
+#[derive(Decode, Encode, Debug, Clone, Eq, PartialEq, Default)]
 pub enum TransportScramblingControl {
     #[default]
     NotScrambled,
     UserDefined(u8),
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, Eq, PartialEq, Default)]
+#[derive(Decode, Encode, Debug, Clone, Eq, PartialEq, Default)]
 pub enum AdaptationFieldControl {
     #[default]
     PayloadOnly,

--- a/common/src/mpegts/payload.rs
+++ b/common/src/mpegts/payload.rs
@@ -1,6 +1,6 @@
-use serde::{Deserialize, Serialize};
+use bincode::{Decode, Encode};
 
-#[derive(Serialize, Deserialize, Debug, Clone, Eq, PartialEq, Default)]
+#[derive(Decode, Encode, Debug, Clone, Eq, PartialEq, Default)]
 pub struct RawPayload {
     pub data: Vec<u8>,
 }

--- a/common/src/mpegts/pes.rs
+++ b/common/src/mpegts/pes.rs
@@ -9,10 +9,10 @@ use crate::utils::bits::BitReader;
 use constants::*;
 use enums::StreamType;
 use header::PesHeader;
-use serde::{Deserialize, Serialize};
+use bincode::{Decode, Encode};
 use std::cmp::PartialEq;
 
-#[derive(Serialize, Deserialize, Debug, Clone, Eq, PartialEq)]
+#[derive(Decode, Encode, Debug, Clone, Eq, PartialEq)]
 pub struct PacketizedElementaryStream {
     pub required_fields: RequiredFields,
     pub header: Option<PesHeader>,
@@ -20,7 +20,7 @@ pub struct PacketizedElementaryStream {
     pub padding_bytes: Option<Vec<u8>>,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, Eq, PartialEq)]
+#[derive(Decode, Encode, Debug, Clone, Eq, PartialEq)]
 pub struct RequiredFields {
     pub packet_start_code_prefix: u32,
     pub stream_id: u8,

--- a/common/src/mpegts/pes/enums.rs
+++ b/common/src/mpegts/pes/enums.rs
@@ -1,6 +1,6 @@
-use serde::{Deserialize, Serialize};
+use bincode::{Decode, Encode};
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+#[derive(Decode, Encode, Debug, PartialEq, Clone)]
 pub enum StreamType {
     ProgramStreamMap,
     PrivateStream1,
@@ -27,7 +27,7 @@ pub enum StreamType {
     Unknown,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, Eq, PartialEq)]
+#[derive(Decode, Encode, Debug, Clone, Eq, PartialEq)]
 pub enum TrickModeControlValues {
     FastForward,
     SlowMotion,
@@ -37,7 +37,7 @@ pub enum TrickModeControlValues {
     Reserved,
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq)]
+#[derive(Decode, Encode, Debug, PartialEq)]
 pub enum PtsDtsFlags {
     No,
     Forbidden,

--- a/common/src/mpegts/pes/header.rs
+++ b/common/src/mpegts/pes/header.rs
@@ -1,9 +1,9 @@
 use super::constants::*;
 use super::optional_fields::OptionalFields;
 use crate::utils::traits::{BitManipulation, DataParser, DataValidator};
-use serde::{Deserialize, Serialize};
+use bincode::{Decode, Encode};
 
-#[derive(Serialize, Deserialize, Debug, Clone, Eq, PartialEq)]
+#[derive(Decode, Encode, Debug, Clone, Eq, PartialEq)]
 pub struct PesHeader {
     pub size: usize,
     pub scrambling_control: u8,

--- a/common/src/mpegts/pes/optional_fields.rs
+++ b/common/src/mpegts/pes/optional_fields.rs
@@ -3,13 +3,13 @@ mod tests;
 
 use crate::utils::traits::{BitManipulation, DataParser, DataValidator};
 use crate::utils::{BitReader, PesExtensionReader, TimestampReader};
-use serde::{Deserialize, Serialize};
+use bincode::{Decode, Encode};
 
 use super::constants::*;
 use super::enums::PtsDtsFlags;
 use super::trick_mode_control::TrickModeControl;
 
-#[derive(Serialize, Deserialize, Debug, Clone, Eq, PartialEq)]
+#[derive(Decode, Encode, Debug, Clone, Eq, PartialEq)]
 pub struct OptionalFields {
     pub size: u8,
     pub pts: Option<u64>,
@@ -22,7 +22,7 @@ pub struct OptionalFields {
     pub previous_pes_packet_crc: Option<u16>,
     pub pes_extension_data: Option<PesExtensionData>,
 }
-#[derive(Serialize, Deserialize, Debug, Clone, Eq, PartialEq)]
+#[derive(Decode, Encode, Debug, Clone, Eq, PartialEq)]
 pub struct PesExtensionData {
     pub size: u8,
     pub pes_private_data_flag: bool,
@@ -45,7 +45,7 @@ pub struct PesExtensionData {
     pub tref: Option<u64>,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, Eq, PartialEq)]
+#[derive(Decode, Encode, Debug, Clone, Eq, PartialEq)]
 pub struct ContextFlags {
     pub pts_dts_flags: u8,
     pub escr_flag: bool,

--- a/common/src/mpegts/pes/pes_buffer.rs
+++ b/common/src/mpegts/pes/pes_buffer.rs
@@ -4,9 +4,9 @@ mod tests;
 use super::{PacketizedElementaryStream, REQUIRED_FIELDS_SIZE};
 use crate::mpegts::MpegtsFragment;
 use crate::utils::BufferOperations;
-use serde::{Deserialize, Serialize};
+use bincode::{Decode, Encode};
 
-#[derive(Serialize, Deserialize, Debug, Clone, Default)]
+#[derive(Decode, Encode, Debug, Clone, Default)]
 pub struct PesPacketPayload {
     data: Vec<u8>,
     is_completable: bool,
@@ -68,7 +68,7 @@ impl BufferOperations for PesPacketPayload {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, Default)]
+#[derive(Decode, Encode, Debug, Clone, Default)]
 pub struct PesBuffer {
     payload: PesPacketPayload,
 }

--- a/common/src/mpegts/pes/trick_mode_control.rs
+++ b/common/src/mpegts/pes/trick_mode_control.rs
@@ -1,8 +1,8 @@
-use serde::{Deserialize, Serialize};
+use bincode::{Decode, Encode};
 
 use super::enums::TrickModeControlValues;
 
-#[derive(Serialize, Deserialize, Debug, Clone, Eq, PartialEq)]
+#[derive(Decode, Encode, Debug, Clone, Eq, PartialEq)]
 pub struct TrickModeControl {
     pub trick_mode_control: TrickModeControlValues,
     pub field_id: Option<u8>,

--- a/common/src/mpegts/psi.rs
+++ b/common/src/mpegts/psi.rs
@@ -1,4 +1,4 @@
-use serde::{Deserialize, Serialize};
+use bincode::{Decode, Encode};
 
 pub mod constants;
 pub mod pat;
@@ -12,7 +12,7 @@ pub trait ProgramSpecificInformation {
     fn get_table_id(&self) -> TableId;
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, Ord, PartialOrd, Eq)]
+#[derive(Decode, Encode, Debug, Clone, Ord, PartialOrd, Eq)]
 pub struct ProgramSpecificInformationHeader {
     pub table_id: u8,
     pub section_syntax_indicator: bool,
@@ -23,14 +23,14 @@ pub struct ProgramSpecificInformationHeader {
     pub last_section_number: u8,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, Eq, PartialEq)]
+#[derive(Decode, Encode, Debug, Clone, Eq, PartialEq)]
 pub enum PsiTypes {
     PAT(u16), //transport_stream_id
     PMT(u16), // pid value
     NONE,
 }
 
-#[derive(Serialize, PartialEq, Eq, Deserialize, Debug, Clone)]
+#[derive(Encode, PartialEq, Eq, Decode, Debug, Clone)]
 pub enum TableId {
     ProgramAssociationSection,
     ConditionalAccessSection,

--- a/common/src/mpegts/psi/pat.rs
+++ b/common/src/mpegts/psi/pat.rs
@@ -4,9 +4,9 @@ pub mod pat_buffer;
 
 use crate::utils::{BitReader, Crc32Reader};
 use constants::*;
-use serde::{Deserialize, Serialize};
+use bincode::{Decode, Encode};
 
-#[derive(Serialize, Deserialize, Debug, Clone, Ord, PartialOrd, Eq)]
+#[derive(Decode, Encode, Debug, Clone, Ord, PartialOrd, Eq)]
 pub struct ProgramAssociationTable {
     pub transport_stream_id: u16,
     pub programs: Vec<ProgramAssociationItem>,
@@ -14,7 +14,7 @@ pub struct ProgramAssociationTable {
     pub fragment_count: usize,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, Ord, PartialOrd, Eq)]
+#[derive(Decode, Encode, Debug, Clone, Ord, PartialOrd, Eq)]
 pub struct ProgramAssociationItem {
     pub program_number: u16,
     pub network_pid: Option<u16>,

--- a/common/src/mpegts/psi/pat/fragmentary_pat.rs
+++ b/common/src/mpegts/psi/pat/fragmentary_pat.rs
@@ -7,9 +7,9 @@ use crate::mpegts::psi::{
     constants::*, ProgramSpecificInformation, ProgramSpecificInformationHeader, TableId,
 };
 use crate::utils::{BitReader, DataParser, DataValidator};
-use serde::{Deserialize, Serialize};
+use bincode::{Decode, Encode};
 
-#[derive(Serialize, Deserialize, Debug, Clone, Ord, PartialOrd, Eq)]
+#[derive(Decode, Encode, Debug, Clone, Ord, PartialOrd, Eq)]
 pub struct FragmentaryProgramAssociationTable {
     pub header: ProgramSpecificInformationHeader,
     pub transport_stream_id: u16,

--- a/common/src/mpegts/psi/pat/pat_buffer.rs
+++ b/common/src/mpegts/psi/pat/pat_buffer.rs
@@ -5,9 +5,9 @@ use crate::mpegts::psi::pat::fragmentary_pat::FragmentaryProgramAssociationTable
 use crate::mpegts::psi::pat::ProgramAssociationTable;
 use crate::mpegts::psi::psi_buffer::PsiBuffer;
 use crate::utils::{DataAccumulator, DataValidator};
-use serde::{Deserialize, Serialize};
+use bincode::{Decode, Encode};
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Decode, Encode, Debug, Clone)]
 pub struct PatBuffer {
     last_section_number: u8,
     pat_fragments: Vec<FragmentaryProgramAssociationTable>,

--- a/common/src/mpegts/psi/pmt.rs
+++ b/common/src/mpegts/psi/pmt.rs
@@ -6,10 +6,10 @@ pub mod stream_types;
 use crate::mpegts::descriptors::Descriptors;
 use crate::mpegts::psi::pmt::stream_types::StreamType;
 use crate::utils::{BitReader, Crc32Reader};
+use bincode::{Decode, Encode};
 use constants::*;
-use serde::{Deserialize, Serialize};
 
-#[derive(Serialize, Deserialize, Debug, Clone, Ord, PartialOrd, Eq)]
+#[derive(Decode, Encode, Debug, Clone, Ord, PartialOrd, Eq)]
 pub struct ProgramMapTable {
     pub fields: PmtFields,
     pub descriptors: Vec<Descriptors>,
@@ -18,7 +18,7 @@ pub struct ProgramMapTable {
     pub fragment_count: usize,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, Ord, PartialOrd, Eq)]
+#[derive(Decode, Encode, Debug, Clone, Ord, PartialOrd, Eq)]
 pub struct PmtFields {
     pub program_number: u16,
     pub pcr_pid: u16,
@@ -46,7 +46,7 @@ impl PartialEq for PmtFields {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, Ord, PartialOrd, Eq)]
+#[derive(Decode, Encode, Debug, Clone, Ord, PartialOrd, Eq)]
 pub struct ElementaryStreamInfo {
     pub stream_type: StreamType, // table is defined on page 55 of H.222.0 (03/2017)
     pub elementary_pid: u16,

--- a/common/src/mpegts/psi/pmt/fragmentary_pmt.rs
+++ b/common/src/mpegts/psi/pmt/fragmentary_pmt.rs
@@ -5,9 +5,9 @@ use crate::mpegts::psi::pmt::{constants::*, PmtFields};
 use crate::mpegts::psi::psi_buffer::FragmentaryPsi;
 use crate::mpegts::psi::{constants::*, ProgramSpecificInformationHeader};
 use crate::utils::{BitReader, DataParser, DataValidator};
-use serde::{Deserialize, Serialize};
+use bincode::{Decode, Encode};
 
-#[derive(Serialize, Deserialize, Debug, Clone, Ord, PartialOrd, Eq)]
+#[derive(Decode, Encode, Debug, Clone, Ord, PartialOrd, Eq)]
 pub struct FragmentaryProgramMapTable {
     pub header: ProgramSpecificInformationHeader,
     pub fields: PmtFields,

--- a/common/src/mpegts/psi/pmt/pmt_buffer.rs
+++ b/common/src/mpegts/psi/pmt/pmt_buffer.rs
@@ -5,9 +5,9 @@ use crate::mpegts::psi::pmt::fragmentary_pmt::FragmentaryProgramMapTable;
 use crate::mpegts::psi::pmt::{PmtFields, ProgramMapTable};
 use crate::mpegts::psi::psi_buffer::PsiBuffer;
 use crate::utils::{DataAccumulator, DataValidator};
-use serde::{Deserialize, Serialize};
+use bincode::{Decode, Encode};
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Decode, Encode, Debug, Clone)]
 pub struct PmtBuffer {
     last_section_number: u8,
     pmt_fragments: Vec<FragmentaryProgramMapTable>,

--- a/common/src/mpegts/psi/pmt/stream_types.rs
+++ b/common/src/mpegts/psi/pmt/stream_types.rs
@@ -1,10 +1,10 @@
 #[cfg(test)]
 mod tests;
 
-use serde::{Deserialize, Serialize};
+use bincode::{Decode, Encode};
 use std::fmt::Display;
 
-#[derive(Serialize, PartialEq, Eq, Deserialize, Debug, Clone, Copy, Ord, PartialOrd, Hash)]
+#[derive(Encode, PartialEq, Eq, Decode, Debug, Clone, Copy, Ord, PartialOrd, Hash)]
 pub enum StreamType {
     Reserved,
     Video111722,

--- a/common/src/packet.rs
+++ b/common/src/packet.rs
@@ -1,5 +1,5 @@
 use super::{MpegtsPacket, RtcpPacket, RtpPacket};
-use serde::{Deserialize, Serialize};
+use bincode::{Decode, Encode};
 
 use std::net::SocketAddr;
 use std::str::FromStr;
@@ -17,7 +17,7 @@ use pnet_packet::{
     Packet as _,
 };
 
-#[derive(Serialize, Deserialize, PartialEq, Debug, Copy, Clone)]
+#[derive(Encode, Decode, PartialEq, Debug, Copy, Clone)]
 pub enum SessionProtocol {
     Unknown,
     Rtp,
@@ -57,7 +57,7 @@ impl fmt::Display for SessionProtocol {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, Copy, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Decode, Encode, Debug, Copy, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub enum TransportProtocol {
     Tcp,
     Udp,
@@ -74,7 +74,7 @@ impl fmt::Display for TransportProtocol {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Decode, Encode, Debug, Clone)]
 pub enum SessionPacket {
     Unknown,
     Rtp(RtpPacket),
@@ -82,7 +82,7 @@ pub enum SessionPacket {
     Mpegts(MpegtsPacket),
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Encode, Decode, Debug, Clone)]
 pub struct Packet {
     pub payload: Option<Vec<u8>>,
     pub id: usize,

--- a/common/src/rtcp.rs
+++ b/common/src/rtcp.rs
@@ -2,7 +2,7 @@ pub use goodbye::Goodbye;
 pub use receiver_report::ReceiverReport;
 pub use reception_report::ReceptionReport;
 pub use sender_report::SenderReport;
-use serde::{Deserialize, Serialize};
+use bincode::{Decode, Encode};
 pub use source_description::SourceDescription;
 
 pub mod goodbye;
@@ -11,7 +11,7 @@ pub mod reception_report;
 pub mod sender_report;
 pub mod source_description;
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Decode, Encode, Debug, Clone)]
 pub enum RtcpPacket {
     SenderReport(sender_report::SenderReport),
     ReceiverReport(receiver_report::ReceiverReport),

--- a/common/src/rtcp/goodbye.rs
+++ b/common/src/rtcp/goodbye.rs
@@ -1,6 +1,6 @@
-use serde::{Deserialize, Serialize};
+use bincode::{Decode, Encode};
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Decode, Encode, Debug, Clone)]
 pub struct Goodbye {
     pub sources: Vec<u32>,
     pub reason: String,

--- a/common/src/rtcp/receiver_report.rs
+++ b/common/src/rtcp/receiver_report.rs
@@ -1,7 +1,7 @@
 use super::reception_report::ReceptionReport;
-use serde::{Deserialize, Serialize};
+use bincode::{Decode, Encode};
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Decode, Encode, Debug, Clone)]
 pub struct ReceiverReport {
     pub ssrc: u32,
     pub reports: Vec<ReceptionReport>,

--- a/common/src/rtcp/reception_report.rs
+++ b/common/src/rtcp/reception_report.rs
@@ -1,6 +1,6 @@
-use serde::{Deserialize, Serialize};
+use bincode::{Decode, Encode};
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Decode, Encode, Debug, Clone)]
 pub struct ReceptionReport {
     pub ssrc: u32,
     pub fraction_lost: u8,

--- a/common/src/rtcp/sender_report.rs
+++ b/common/src/rtcp/sender_report.rs
@@ -1,7 +1,7 @@
 use super::reception_report::ReceptionReport;
-use serde::{Deserialize, Serialize};
+use bincode::{Decode, Encode};
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Decode, Encode, Debug, Clone)]
 pub struct SenderReport {
     pub ssrc: u32,
     pub ntp_time: u64,

--- a/common/src/rtcp/source_description.rs
+++ b/common/src/rtcp/source_description.rs
@@ -1,7 +1,7 @@
-use serde::{Deserialize, Serialize};
+use bincode::{Decode, Encode};
 use std::fmt;
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Decode, Encode, Debug, Clone)]
 pub struct SourceDescription {
     pub chunks: Vec<SourceDescriptionChunk>,
 }
@@ -19,7 +19,7 @@ impl SourceDescription {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Decode, Encode, Debug, Clone)]
 pub struct SourceDescriptionChunk {
     pub source: u32,
     pub items: Vec<SourceDescriptionItem>,
@@ -37,7 +37,7 @@ impl SourceDescriptionChunk {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Decode, Encode, Debug, Clone)]
 pub struct SourceDescriptionItem {
     pub sdes_type: SdesType,
     pub text: String,
@@ -55,7 +55,7 @@ impl SourceDescriptionItem {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[derive(Decode, Encode, Debug, Clone, PartialEq)]
 pub enum SdesType {
     End,
     Cname,

--- a/common/src/rtp.rs
+++ b/common/src/rtp.rs
@@ -1,9 +1,9 @@
 use payload_type::PayloadType;
-use serde::{Deserialize, Serialize};
+use bincode::{Decode, Encode};
 
 pub mod payload_type;
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Decode, Encode, Debug, Clone)]
 pub struct RtpPacket {
     pub version: u8,
     pub padding: bool,

--- a/common/src/rtp/payload_type.rs
+++ b/common/src/rtp/payload_type.rs
@@ -1,7 +1,7 @@
-use serde::{Deserialize, Serialize};
+use bincode::{Decode, Encode};
 use std::fmt;
 
-#[derive(Serialize, Deserialize, Debug, Clone, Copy)]
+#[derive(Decode, Encode, Debug, Clone, Copy)]
 pub enum MediaType {
     Audio,
     Video,
@@ -20,7 +20,7 @@ impl fmt::Display for MediaType {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Decode, Encode, Debug, Clone)]
 pub struct PayloadType {
     pub id: u8,
     pub name: String,

--- a/common/src/sdp.rs
+++ b/common/src/sdp.rs
@@ -1,8 +1,8 @@
 use crate::rtp::payload_type::PayloadType;
-use serde::{Deserialize, Serialize};
+use bincode::{Decode, Encode};
 use std::collections::HashMap;
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Decode, Encode, Debug, Clone)]
 pub struct Sdp {
     pub payload_types: HashMap<u8, PayloadType>,
 }


### PR DESCRIPTION
This pull request includes significant changes to the serialization and deserialization mechanisms in the codebase, replacing `serde` with `bincode`. 

### Serialization and Deserialization Updates:

* Updated `Cargo.toml` files to use `bincode` version `2.0.0-rc.3` instead of `1.3`. 

These changes improve the performance and reliability of serialization and deserialization processes and ensure the codebase is up-to-date with the latest `bincode` version.