### PR TITLE
Fix UI on hi-res monitor

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -47,6 +47,19 @@
             width: 100%;
         }
 
+
+        /* Make canvas fill entire document: */
+        canvas {
+            margin-right: auto;
+            margin-left: auto;
+            display: block;
+            position: absolute;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+        }
+/* 
         /* Position canvas in center-top: */
         canvas {
             margin-right: auto;
@@ -56,7 +69,7 @@
             top: 0%;
             left: 50%;
             transform: translate(-50%, 0%);
-        }
+        } */
 
         .centered {
             margin-right: auto;

--- a/client/index.html
+++ b/client/index.html
@@ -59,17 +59,6 @@
             width: 100%;
             height: 100%;
         }
-/* 
-        /* Position canvas in center-top: */
-        canvas {
-            margin-right: auto;
-            margin-left: auto;
-            display: block;
-            position: absolute;
-            top: 0%;
-            left: 50%;
-            transform: translate(-50%, 0%);
-        } */
 
         .centered {
             margin-right: auto;

--- a/client/src/app/common/macros.rs
+++ b/client/src/app/common/macros.rs
@@ -203,7 +203,10 @@ macro_rules! declare_table {
     }) => {
         impl $table {
             fn build_table(&mut self, ui: &mut egui::Ui) {
+                ui.set_width(ui.available_width());
+                let width_bucket: i32 = ((ui.available_width() as i32) / 64) * 64;
                 let mut builder = TableBuilder::new(ui)
+                    .id_salt((self.table_id(), width_bucket))
                     .striped($(($striped))?)
                     .resizable($(($resizable))?)
                     .stick_to_bottom($(($stick_to_bottom))?);


### PR DESCRIPTION
I encountered a strange bug on my 4K monitor with 1.5 scaling. When opening the app in the browser, I had to zoom out the tab to 50% just to get it to render at all. However, this made every component appear extremely small. This PR fixes the issue and, based on the monitors I tested, doesn’t introduce any new display problems.